### PR TITLE
Add placeholder for poses with missing images

### DIFF
--- a/components/PoseCard.tsx
+++ b/components/PoseCard.tsx
@@ -79,11 +79,15 @@ export default function PoseCard({ pose, isFavorited }: Props) {
             },
           }}
         >
-          <img
-            src={image_url}
-            alt=""
-            className="pointer-events-none object-cover group-hover:opacity-75"
-          />
+          {image_url ? (
+            <img
+              src={image_url}
+              alt=""
+              className="pointer-events-none object-cover group-hover:opacity-75"
+            />
+          ) : (
+            <div className="w-full h-[128px] md:h-[150px] pointer-events-none object-cover group-hover:opacity-75"></div>
+          )}
         </Link>
         {user ? (
           <FavoritePoseButton

--- a/lib/typeDefs/types.ts
+++ b/lib/typeDefs/types.ts
@@ -2,7 +2,7 @@ type Pose = {
   id: number;
   title: string;
   subtitle: string;
-  image_url: string;
+  image_url?: string;
 };
 
 type Exercise = {


### PR DESCRIPTION
Display an empty `div` element when pictures are missing for yoga poses. 